### PR TITLE
Update TrackableRepository to set entity state vs apply changes.

### DIFF
--- a/URF.Core.EF.Trackable/TrackableRepository.cs
+++ b/URF.Core.EF.Trackable/TrackableRepository.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TrackableEntities.Common.Core;
@@ -16,19 +15,29 @@ namespace URF.Core.EF.Trackable
         }
 
         public override void Insert(TEntity item)
-            => SetStateAndApplyChanges(x => x.TrackingState = TrackingState.Added, item);
+        {
+            item.TrackingState = TrackingState.Added;
+            base.Insert(item);
+        }
 
         public override void Update(TEntity item)
-            => SetStateAndApplyChanges(x => x.TrackingState = TrackingState.Modified, item);
+        {
+            item.TrackingState = TrackingState.Modified;
+            base.Insert(item);
+        }
 
         public override void Delete(TEntity item)
-            => SetStateAndApplyChanges(x => x.TrackingState = TrackingState.Deleted, item);
+        {
+            item.TrackingState = TrackingState.Deleted;
+            base.Insert(item);
+        }
 
         public override async Task<bool> DeleteAsync(object[] keyValues, CancellationToken cancellationToken = default)
         {
             var item = await FindAsync(keyValues, cancellationToken);
             if (item == null) return false;
-                SetStateAndApplyChanges(x => x.TrackingState = TrackingState.Deleted, item);
+            item.TrackingState = TrackingState.Deleted;
+            Context.Entry(item).State = EntityState.Deleted;
             return true;
         }
 
@@ -43,11 +52,5 @@ namespace URF.Core.EF.Trackable
 
         public virtual async Task LoadRelatedEntities(params TEntity[] entities)
             => await Context.LoadRelatedEntitiesAsync(entities);
-
-        private void SetStateAndApplyChanges(Action<TEntity> setState, TEntity item)
-        {
-            setState(item);
-            ApplyChanges(item);
-        }
     }
 }


### PR DESCRIPTION
We should set the entity state vs call ApplyChanges in order to remain consistent with base Repository implementation.