### PR TITLE
Fix Where Clause LINQ expression Queryable  could not be translated.

### DIFF
--- a/URF.Core.EF.Tests/RepositoryTest.cs
+++ b/URF.Core.EF.Tests/RepositoryTest.cs
@@ -270,7 +270,7 @@ namespace URF.Core.EF.Tests
             Assert.Collection(paginated.Value, collectionAssertions);
         }
 
-        [Fact(Skip = "Throws InvalidOperationException: Operation is not valid due to the current state of the object.")]
+        [Fact]
         public async Task Queryable_Should_Allow_Composition()
         {
             // Arrange
@@ -285,7 +285,7 @@ namespace URF.Core.EF.Tests
             var products = await query
                 .Take(2)
                 .Include(p => p.Category)
-                .Where(p => p.UnitPrice > 15)
+                .Where(p => p.UnitPrice.CompareTo(15.00m) > 0 )
                 .Select(p => new MyProduct
                 {
                     Id = p.ProductId,


### PR DESCRIPTION
Prior to version 3.0, Entity Framework Core supported client evaluation anywhere in the query.
The LINQ expression 'DbSet<Product> .Take(__p_0)  .Where(e => e.UnitPrice > 15)' 
could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.

CompareTo(Decimal) usage
https://docs.microsoft.com/en-us/dotnet/api/system.decimal.compareto?view=netcore-3.1